### PR TITLE
Prctl cfi fix

### DIFF
--- a/sysdeps/riscv/__longjmp.S
+++ b/sysdeps/riscv/__longjmp.S
@@ -51,6 +51,36 @@ ENTRY (__longjmp)
 	FREG_L fs11,14*SZREG+11*SZFREG(a0)
 #endif
 
+#ifdef __riscv_zicfiss
+        /* read ssp into t0  */
+        ssrdp t0
+        /* skip unwinding if ss is not enabled  */
+        beqz  t0, unwind_fin
+# ifndef __riscv_float_abi_soft
+	REG_L t1, 14*SZREG+12*SZFREG(a0)
+# else
+	REG_L t1, 14*SZREG(a0)
+# endif
+unwind:
+        /* should not be taken in normal condition  */
+        bleu  t1, t0, unwind_fin
+        /* The unwiding algorithm came from the zicfiss spec, increase ssp
+           by at most a page size to ensure always run into a guard page
+           before accidentally point to another legal shadow stack page  */
+        /* t0 = (t1 - t0 >= 4096) ? t0 + 4096 : t1  */
+        lui   a0, 1
+        add   t0, t0, a0
+        bleu  t0, t1, 1f
+        mv    t0, t1
+1:
+        csrw  ssp, t0
+        /* Test if the location pointed by ssp is legal  */
+        sspush x5
+        sspopchk x5
+        j unwind
+unwind_fin:
+#endif
+
 	seqz a0, a1
 	add  a0, a0, a1   # a0 = (a1 == 0) ? 1 : a1
 	ret

--- a/sysdeps/riscv/bits/setjmp.h
+++ b/sysdeps/riscv/bits/setjmp.h
@@ -34,6 +34,10 @@ typedef struct __jmp_buf_internal_tag
 #elif !defined __riscv_float_abi_soft
 # error unsupported FLEN
 #endif
+#ifdef __riscv_zicfiss
+    /* Shadow tack pointer.  */
+    long int __ssp;
+#endif
   } __jmp_buf[1];
 
 #endif /* _RISCV_BITS_SETJMP_H */

--- a/sysdeps/riscv/dl-cfi.c
+++ b/sysdeps/riscv/dl-cfi.c
@@ -93,7 +93,7 @@ _dl_cfi_setup_features (unsigned int feature_1)
 #ifdef __riscv_zicfilp
   if (feature_1 & GNU_PROPERTY_RISCV_FEATURE_1_FCFI)
     INTERNAL_SYSCALL_CALL (prctl, PR_SET_INDIR_BR_LP_STATUS,
-                           PR_INDIR_BR_LP_ENABLE);
+                           PR_INDIR_BR_LP_ENABLE, 0, 0, 0);
 #endif /* __riscv_zicfilp  */
   /* FIXME: Read enabled features from kernel and re-sync  */
 }

--- a/sysdeps/riscv/setjmp.S
+++ b/sysdeps/riscv/setjmp.S
@@ -61,6 +61,16 @@ ENTRY (__sigsetjmp)
 	FREG_S fs11,14*SZREG+11*SZFREG(a0)
 #endif
 
+#ifdef __riscv_zicfiss
+        /* read ssp into t0  */
+        ssrdp t0
+# ifndef __riscv_float_abi_soft
+	REG_S t0, 14*SZREG+12*SZFREG(a0)
+# else
+	REG_S t0, 14*SZREG(a0)
+# endif
+#endif
+
 #if !IS_IN (libc) && IS_IN (rtld)
   /* In ld.so we never save the signal mask.  */
   li a0, 0

--- a/sysdeps/unix/sysv/linux/riscv/dl-cfi.h
+++ b/sysdeps/unix/sysv/linux/riscv/dl-cfi.h
@@ -27,6 +27,9 @@
     beqz  a0, 1f \n\
     li   a0, " STRINGXP (PR_SET_SHADOW_STACK_STATUS) "\n\
     li   a1, " STRINGXP (PR_SHADOW_STACK_ENABLE) "\n\
+    li   a2, 0 \n\
+    li   a3, 0 \n\
+    li   a4, 0 \n\
     li   a7, " STRINGXP (__NR_prctl) "\n\
     ecall \n\
 1: \n\


### PR DESCRIPTION
linux kernel handling for prctl is to have strict checking on input parameters.
Input parameters not used must be zero.