### PR TITLE
riscv/cfi: cfi prctl enable prctls zero unused params

### DIFF
--- a/sysdeps/riscv/dl-cfi.c
+++ b/sysdeps/riscv/dl-cfi.c
@@ -93,7 +93,7 @@ _dl_cfi_setup_features (unsigned int feature_1)
 #ifdef __riscv_zicfilp
   if (feature_1 & GNU_PROPERTY_RISCV_FEATURE_1_FCFI)
     INTERNAL_SYSCALL_CALL (prctl, PR_SET_INDIR_BR_LP_STATUS,
-                           PR_INDIR_BR_LP_ENABLE);
+                           PR_INDIR_BR_LP_ENABLE, 0, 0, 0);
 #endif /* __riscv_zicfilp  */
   /* FIXME: Read enabled features from kernel and re-sync  */
 }

--- a/sysdeps/unix/sysv/linux/riscv/dl-cfi.h
+++ b/sysdeps/unix/sysv/linux/riscv/dl-cfi.h
@@ -27,6 +27,9 @@
     beqz  a0, 1f \n\
     li   a0, " STRINGXP (PR_SET_SHADOW_STACK_STATUS) "\n\
     li   a1, " STRINGXP (PR_SHADOW_STACK_ENABLE) "\n\
+    li   a2, 0 \n\
+    li   a3, 0 \n\
+    li   a4, 0 \n\
     li   a7, " STRINGXP (__NR_prctl) "\n\
     ecall \n\
 1: \n\


### PR DESCRIPTION
linux kernel handling for prctl is to have strict checking on input parameters. Input parameters not used must be zero.